### PR TITLE
Make it so the configure class actually works

### DIFF
--- a/manifests/agent/configure.pp
+++ b/manifests/agent/configure.pp
@@ -65,7 +65,7 @@ class logdna::agent::configure(
 
     if $exclude_regex and !empty($exclude_regex) {
         $exclude_regex.each |String $exclude_pattern| {
-            exec { "LogDNA - Adding Log Exclusion - ${exclude_path}":
+            exec { "LogDNA - Adding Log Exclusion - ${exclude_pattern}":
                 command => "/usr/bin/logdna-agent -r ${exclude_pattern}"
             }
         }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,7 +59,16 @@ class logdna (
     }
 
     if $agent_configure {
-        include logdna::agent::configure
+        class {'logdna::agent::configure':
+            key            => $conf_key,
+            config         => $conf_config,
+            logdir         => $conf_logdir,
+            logfile        => $conf_logfile,
+            tags           => $conf_tags,
+            hostname       => $conf_hostname,
+            exclude        => $conf_exclude,
+            esxclude_regex => $conf_exclude_regex
+        }
     }
 
     if $agent_service == 'stop' or $conf_key {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,14 +60,14 @@ class logdna (
 
     if $agent_configure {
         class {'logdna::agent::configure':
-            key            => $conf_key,
-            config         => $conf_config,
-            logdirs        => $conf_logdir,
-            logfiles       => $conf_logfile,
-            tags           => $conf_tags,
-            hostname       => $conf_hostname,
-            exclude        => $conf_exclude,
-            exclude_regex  => $conf_exclude_regex
+            key           => $conf_key,
+            config        => $conf_config,
+            logdirs       => $conf_logdir,
+            logfiles      => $conf_logfile,
+            tags          => $conf_tags,
+            hostname      => $conf_hostname,
+            exclude       => $conf_exclude,
+            exclude_regex => $conf_exclude_regex
         }
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,9 +33,9 @@
 class logdna (
     Optional[String] $conf_key            = $logdna::params::conf_key,
     Optional[String] $conf_config         = $logdna::params::conf_config,
-    Optional[String] $conf_logdir         = $logdna::params::conf_logdir,
-    Optional[String] $conf_logfile        = $logdna::params::conf_logfile,
-    Optional[String] $conf_tags           = $logdna::params::conf_tags,
+    Optional[Array[String]] $conf_logdir  = $logdna::params::conf_logdir,
+    Optional[Array[String]] $conf_logfile = $logdna::params::conf_logfile,
+    Optional[Array[String]] $conf_tags    = $logdna::params::conf_tags,
     Optional[String] $conf_hostname       = $logdna::params::conf_hostname,
     Optional[String] $conf_exclude        = $logdna::params::conf_exclude,
     Optional[String] $conf_exclude_regex  = $logdna::params::conf_exclude_regex,
@@ -62,12 +62,12 @@ class logdna (
         class {'logdna::agent::configure':
             key            => $conf_key,
             config         => $conf_config,
-            logdir         => $conf_logdir,
-            logfile        => $conf_logfile,
+            logdirs        => $conf_logdir,
+            logfiles       => $conf_logfile,
             tags           => $conf_tags,
             hostname       => $conf_hostname,
             exclude        => $conf_exclude,
-            esxclude_regex => $conf_exclude_regex
+            exclude_regex  => $conf_exclude_regex
         }
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -31,7 +31,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 6.0.0"
+      "version_requirement": ">= 4.0.0 < 6.0.0"
     }
   ],
   "pdk-version": "1.4.1",

--- a/metadata.json
+++ b/metadata.json
@@ -5,10 +5,6 @@
   "summary": "Puppet module to install and configure LogDNA Agent",
   "license": "MIT",
   "source": "https://github.com/logdna/puppet-logdna",
-  "dependencies": [
-    "puppetlabs/apt",
-    "puppetlabs/stdlib"
-  ],
   "operatingsystem_support": [
     {
       "operatingsystem": "CentOS",
@@ -29,7 +25,7 @@
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.2.0 <5.0.0"},
-    {"name":"puppetlabs/apt","version_requirement":">= 1.8.0 <3.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">= 1.8.0 <5.0.0"},
     {"name":"puppetlabs/package","version_requirement":">=0.2.0 <0.3.0"}
   ],
   "requirements": [

--- a/metadata.json
+++ b/metadata.json
@@ -31,7 +31,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0 < 6.0.0"
     }
   ],
   "pdk-version": "1.4.1",


### PR DESCRIPTION
The current version of this project is very broken- it can install the module, but it can't configure it. This attempts to fix a few of the most pressing bugs-

* The `configure` class was being called without passing any parameters to it, which meant that those parameters were being silently discarded.

* The `configure` class was using the `logdna-agent` command but always with the `k` option, so even if parameters were passed they would not get saved (and would actually overwrite the key).

* A lot of strings were used where arrays would have worked better (this is important for people who are using Hiera and want to have defaults as well as role specific logs- something impossible to do with strings but trivial to do with arrays).

* Updated the `apt` module version (was previously locked to `<3`, while the current version used by most people is `4.5.1`).

With these changes the module can actually be used to install and configure LogDNA. However, the original module still relies heavily on "execs" when it would be better to directly create and manage the `/etc/logdna.conf`. This is a larger change that I am willing to take on, but I believe this PR should be merged first as it makes the minimal number of changes to function properly.