### PR TITLE
Increase the allowed version constraints in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -26,11 +26,11 @@
   "dependencies": [
     {
       "name":"puppetlabs/stdlib",
-      "version_requirement":">= 4.2.0 <5.0.0"
+      "version_requirement":">= 4.2.0 <6.0.0"
     },
     {
       "name":"puppetlabs/apt",
-      "version_requirement":">= 1.8.0 <5.0.0"
+      "version_requirement":">= 1.8.0 <7.0.0"
     },
     {
       "name":"puppetlabs/package",


### PR DESCRIPTION
This tiny change widens the version constraints as defined in metadata.json for puppetlabs/stdlib and puppetlabs/apt to allow the latest versions.

See issue #4