### PR TITLE
Use makecache instead of update -y.

### DIFF
--- a/manifests/agent/package/install_redhat.pp
+++ b/manifests/agent/package/install_redhat.pp
@@ -18,8 +18,8 @@ class logdna::agent::package::install_redhat(
         gpgcheck => '0',
     }
 
-    -> exec { 'yum_update':
-        command => '/usr/bin/yum update -y',
+    -> exec { 'yum_makecache':
+        command => '/usr/bin/yum makecache',
         timeout => 600,
         tries   => 5
     }


### PR DESCRIPTION
Running yum update -y will update all of the packages (in all repos) on a system each time puppet is run. Here it's being used to make sure that the package is available in the yum cache so it can be installed which is what makecache does.