### PR TITLE
Enforce HTTPS for repositories, ensure apt-update runs at the right time

### DIFF
--- a/manifests/agent/package/install_debian.pp
+++ b/manifests/agent/package/install_debian.pp
@@ -23,8 +23,7 @@ class logdna::agent::package::install_debian(
 
     exec { 'logdna agent apt update':
       command     => '/usr/bin/apt-get update',
-      require     => Apt::Source['logdna-agent'],
-      subscribe   => Apt::Source['logdna-agent'],
+      subscribe   => File['/etc/apt/sources.list.d/logdna-agent.list]',
       refreshonly => true,
       timeout     => 600,
       tries       => 5

--- a/manifests/agent/package/install_debian.pp
+++ b/manifests/agent/package/install_debian.pp
@@ -23,7 +23,7 @@ class logdna::agent::package::install_debian(
 
     exec { 'logdna agent apt update':
       command     => '/usr/bin/apt-get update',
-      subscribe   => File['/etc/apt/sources.list.d/logdna-agent.list]',
+      subscribe   => File['/etc/apt/sources.list.d/logdna-agent.list'],
       refreshonly => true,
       timeout     => 600,
       tries       => 5

--- a/manifests/agent/package/install_debian.pp
+++ b/manifests/agent/package/install_debian.pp
@@ -12,17 +12,19 @@ class logdna::agent::package::install_debian(
 
     apt::source { 'logdna-agent':
         comment  => 'This is official LogDNA Agent repository',
-        location => 'http://repo.logdna.com',
+        location => 'https://repo.logdna.com',
         release  => 'stable',
         repos    => 'main',
         key      => {
             id     => '02E0C689A9FCC8110A8FECB9C1BF174AEF506BE8',
-            source => 'http://repo.logdna.com/logdna.gpg'
+            source => 'https://repo.logdna.com/logdna.gpg'
         }
     }
 
-    ~> exec { 'logdna agent apt update':
+    exec { 'logdna agent apt update':
       command     => '/usr/bin/apt-get update',
+      require     => Apt::Source['logdna-agent'],
+      subscribe   => Apt::Source['logdna-agent'],
       refreshonly => true,
       timeout     => 600,
       tries       => 5

--- a/manifests/agent/package/install_redhat.pp
+++ b/manifests/agent/package/install_redhat.pp
@@ -12,7 +12,7 @@ class logdna::agent::package::install_redhat(
 
     yumrepo { 'logdna-agent':
         ensure   => 'present',
-        baseurl  => 'http://repo.logdna.com/el6/',
+        baseurl  => 'https://repo.logdna.com/el6/',
         descr    => 'This is official LogDNA Agent repository',
         enabled  => '1',
         gpgcheck => '0',


### PR DESCRIPTION
Switching the exec for the apt update to subscribe to the actual file being added by the apt::source resource seems to be more effective than the previous method (it resolved a bug for us).

This also updates the URLs for the repositories (both debian and redhat) to use HTTPS.